### PR TITLE
Update tag images

### DIFF
--- a/docs/kubernetes/deploy.yaml
+++ b/docs/kubernetes/deploy.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: alertgram
-          image: slok/alertgram:db08cd4
+          image: slok/alertgram:v0.3.2
           envFrom:
             - secretRef:
                 name: alertgram


### PR DESCRIPTION
Tag `slok/alertgram:db08cd4` not found in hub.docker.com